### PR TITLE
complete issue #10 : live score GUI in single game #14

### DIFF
--- a/botplay.py
+++ b/botplay.py
@@ -140,6 +140,9 @@ def botPlay(pygame, screen, menu):
     bg = pygame.image.load("textures/GameBackground.jpg")
     bg = pygame.transform.scale(bg, (WIDTH, HEIGHT))
 
+    font = pygame.font.SysFont('Time New Roman', 60)
+
+
     bot = Player(size, state)
     apple = Apple(xApple, yApple)
 
@@ -154,7 +157,7 @@ def botPlay(pygame, screen, menu):
                 sys.exit()
         # botMove(bot, apple)
         botEasyWin(bot)
-        displayGame(pygame, screen, bot, apple)
+        displayGame(pygame, screen, bot, apple, font)
 
     # End the game
     if not RestartBotGame and bot.state[0]['x'] != -5:

--- a/constant.py
+++ b/constant.py
@@ -21,5 +21,7 @@ SAVE_FILE_GAME = "./savegame.txt"
 SAVE_FILE_SCORES = "./savescores.txt"
 HIGH_SCORES_LENGTH = 10
 
+FontSize = {'score':60}
+
 RestartGameSingle = False
 RestartGameDual = False

--- a/singleplay.py
+++ b/singleplay.py
@@ -130,7 +130,7 @@ def displayGame(pygame, screen, player, apple, font):
 #! screen => pygame window
 #! loadSave => bool for knowing if loading Save Or not
 def singlePlay(pygame, screen, menu, loadSave):
-    screen = pygame.display.set_mode((WIDTH, HEIGHT+FontSize['score']))
+    # screen = pygame.display.set_mode((WIDTH, HEIGHT+FontSize['score']))
 
     clock = pygame.time.Clock()
     size = 1  # default Value

--- a/singleplay.py
+++ b/singleplay.py
@@ -1,3 +1,4 @@
+from msilib.schema import Font
 import sys
 import random
 import time
@@ -112,7 +113,7 @@ def displayGame(pygame, screen, player, apple, font):
             # Play bot Text
     play = font.render(str(player.size), False, WHITE)
     playRect = play.get_rect()
-    playRect.center = (WIDTH//2, 50)
+    playRect.center = (WIDTH//2, HEIGHT +FontSize['score']/2)
     screen.blit(play, playRect)
 
     pygame.display.update()

--- a/singleplay.py
+++ b/singleplay.py
@@ -3,7 +3,7 @@ import sys
 import random
 import time
 
-from constant import HEIGHT, RestartGameSingle, WIDTH, GAMETICK, MODULO_SCREEN, Orientation, WHITE, FontSize
+from constant import BLACK, HEIGHT, RestartGameSingle, WIDTH, GAMETICK, MODULO_SCREEN, Orientation, WHITE, FontSize
 from save import Score, addNewScore, loadingGame, saveGame
 
 
@@ -111,6 +111,11 @@ def displayGame(pygame, screen, player, apple, font):
     screen.blit(a, (apple.x*MODULO_SCREEN, apple.y*MODULO_SCREEN))
 
             # Play bot Text
+    play = font.render(str(player.size-1), False, BLACK)
+    playRect = play.get_rect()
+    playRect.center = (WIDTH//2, HEIGHT +FontSize['score']/2)
+    screen.blit(play, playRect)
+
     play = font.render(str(player.size), False, WHITE)
     playRect = play.get_rect()
     playRect.center = (WIDTH//2, HEIGHT +FontSize['score']/2)

--- a/singleplay.py
+++ b/singleplay.py
@@ -2,7 +2,7 @@ import sys
 import random
 import time
 
-from constant import HEIGHT, RestartGameSingle, WIDTH, GAMETICK, MODULO_SCREEN, Orientation
+from constant import HEIGHT, RestartGameSingle, WIDTH, GAMETICK, MODULO_SCREEN, Orientation, WHITE, FontSize
 from save import Score, addNewScore, loadingGame, saveGame
 
 
@@ -92,7 +92,7 @@ class Player:
 
 
 #! Handle All Display part (and a little more)
-def displayGame(pygame, screen, player, apple):
+def displayGame(pygame, screen, player, apple, font):
     lastX, lastY, lastLook = player.state[len(player.state) - 1]['x'], player.state[len(
         player.state) - 1]['y'], player.state[len(player.state) - 1]['look']
     player.move()
@@ -108,6 +108,13 @@ def displayGame(pygame, screen, player, apple):
     player.CheckEatApple(apple, lastX, lastY, lastLook)
     a = pygame.image.load("textures/Apple.png")
     screen.blit(a, (apple.x*MODULO_SCREEN, apple.y*MODULO_SCREEN))
+
+            # Play bot Text
+    play = font.render(str(player.size), False, WHITE)
+    playRect = play.get_rect()
+    playRect.center = (WIDTH//2, 50)
+    screen.blit(play, playRect)
+
     pygame.display.update()
     pass
 
@@ -117,6 +124,8 @@ def displayGame(pygame, screen, player, apple):
 #! screen => pygame window
 #! loadSave => bool for knowing if loading Save Or not
 def singlePlay(pygame, screen, menu, loadSave):
+    screen = pygame.display.set_mode((WIDTH, HEIGHT+FontSize['score']))
+
     clock = pygame.time.Clock()
     size = 1  # default Value
     xApple, yApple = random.randint(
@@ -126,6 +135,9 @@ def singlePlay(pygame, screen, menu, loadSave):
 
     bg = pygame.image.load("textures/GameBackground.jpg")
     bg = pygame.transform.scale(bg, (WIDTH, HEIGHT))
+
+    font = pygame.font.SysFont('Time New Roman', 60)
+
 
     # Use saved game data
     if loadSave:
@@ -156,7 +168,7 @@ def singlePlay(pygame, screen, menu, loadSave):
                 if event.key == pygame.K_ESCAPE:
                     RestartGameSingle = menu.pauseMenuSinglePlayer(
                         pygame, player, apple, menu)
-        displayGame(pygame, screen, player, apple)
+        displayGame(pygame, screen, player, apple, font)
 
     # End the game
     if not RestartGameSingle and player.state[0]['x'] != -5:

--- a/start.py
+++ b/start.py
@@ -3,7 +3,7 @@ import pygame
 import time
 from botplay import botPlay
 
-from constant import WIDTH, HEIGHT, RestartGameSingle, RestartGameDual
+from constant import WIDTH, HEIGHT, RestartGameSingle, RestartGameDual, FontSize
 from dualplay import dualPlay
 from singleplay import singlePlay
 from menu import Menu
@@ -12,34 +12,48 @@ pygame.init()
 
 speed = [2, 2]
 
-screen = pygame.display.set_mode((WIDTH, HEIGHT))
+def setScreenSize(screenMode):
+    if screenMode == 'screen':
+        return pygame.display.set_mode((WIDTH, HEIGHT))
+    elif screenMode == 'singleScreen':
+        return pygame.display.set_mode((WIDTH, HEIGHT+FontSize['score']))
+    elif screenMode == 'dualScreen':
+        return pygame.display.set_mode((WIDTH, HEIGHT))
+    elif screenMode == 'botScreen':
+        return pygame.display.set_mode((WIDTH, HEIGHT))
+
 pygame.display.set_caption('Snacke')
 
 start = True
 
 # Create Menu
-menu = Menu(pygame, screen)
+menu = Menu(pygame, setScreenSize('screen'))
 
 while True:
+    menu = Menu(pygame, setScreenSize('screen'))
+
     if RestartGameSingle:
-        RestartGameSingle = singlePlay(pygame, screen, menu, False)
+        RestartGameSingle = singlePlay(pygame, setScreenSize('singleScreen'), menu, False)
     if RestartGameDual:
-        RestartGameDual = dualPlay(pygame, screen, menu)
+        RestartGameDual = dualPlay(pygame, setScreenSize('dualScreen'), menu)
     for event in pygame.event.get():
         if event.type == pygame.KEYDOWN:
             if event.key == pygame.K_s:
-                RestartGameSingle = singlePlay(pygame, screen, menu, False)
+                RestartGameSingle = singlePlay(pygame, setScreenSize('singleScreen'), menu, False)
             if event.key == pygame.K_d: ##! Dual player Mode
-                RestartGameDual = dualPlay(pygame, screen, menu)
+                RestartGameDual = dualPlay(pygame, setScreenSize('dualScreen'), menu)
             if event.key == pygame.K_l:
-                RestartGameSingle = singlePlay(pygame, screen, menu, True)
+                RestartGameSingle = singlePlay(pygame, setScreenSize('singleScreen'), menu, True)
             if event.key == pygame.K_r:
                 menu.displayRanking()
                 time.sleep(2)
             if event.key == pygame.K_b:
-                RestartBot = botPlay(pygame, screen, menu)
+                RestartBot = botPlay(pygame, setScreenSize('botScreen'), menu)
             if event.key == pygame.K_e or event.type == pygame.QUIT:
                 pygame.display.quit()
                 pygame.quit()
                 sys.exit()
     menu.displayStartMenu()
+
+
+


### PR DESCRIPTION
To solve issue https://github.com/AntoinePoisson/CAUOpenSourceProject/issues/10


1. SingleMode's screen size was resized.
2. I added new constant dictionafy 'Font_Size' in constant.py
3. I added score bottom of the screen.
4. If Score is updated, before score (ex. now: 7, before: 6) is also updated with black, before to prevent score is stacked on screen
5. in start.py every mode get own size when the play method is started!!

To implement 5, I make new method 'setScreenSize' in start.py

```
def setScreenSize(screenMode):          
    if screenMode == 'screen':  
        return pygame.display.set_mode((WIDTH, HEIGHT))
    elif screenMode == 'singleScreen':
        return pygame.display.set_mode((WIDTH, HEIGHT+FontSize['score']))
    elif screenMode == 'dualScreen':
        return pygame.display.set_mode((WIDTH, HEIGHT))
    elif screenMode == 'botScreen':
        return pygame.display.set_mode((WIDTH, HEIGHT)) 
```
# Single
![image](https://user-images.githubusercontent.com/66313756/174452274-9bf903e3-31b9-4d22-b30b-0c96fbe3cd5e.png)

# Dual
![image](https://user-images.githubusercontent.com/66313756/174452278-c39f46d7-d221-4102-9484-fe708afe32b5.png)

# Bot
![image](https://user-images.githubusercontent.com/66313756/174452288-7a937380-3253-4104-a672-44f48fc3621e.png)

